### PR TITLE
Bug Fix and adding Context menus

### DIFF
--- a/source/Controls/UserRating.xaml.cs
+++ b/source/Controls/UserRating.xaml.cs
@@ -47,6 +47,7 @@ namespace Extras.Controls
                 if (game.UserScore == 0)
                 {
                     game.UserScore = null;
+                    
                 }
             }
         }
@@ -73,6 +74,7 @@ namespace Extras.Controls
                     if (game.UserScore == 0)
                     {
                         game.UserScore = null;
+                        isDragging = false;
                     }
                 }
             }

--- a/source/Extras.cs
+++ b/source/Extras.cs
@@ -97,6 +97,100 @@ namespace Extras
             }
         }
 
+        public override IEnumerable<GameMenuItem> GetGameMenuItems(GetGameMenuItemsArgs args)
+        {
+            Game GameMenu = args.Games.First();
+
+            List<GameMenuItem> gameMenuItems = new List<GameMenuItem>();
+
+            gameMenuItems.Add(new GameMenuItem
+            {
+                Description = "1 Star",
+                MenuSection = $"Theme Extras | Ratings | Set User Rating",
+                
+                Action = (mainMenuItem) =>
+                {
+                    var games = args.Games.Distinct();
+
+                    foreach (Game game in games)
+                    {
+                        game.UserScore = 20;
+                        Playnite.SDK.API.Instance.Database.Games.Update(game);
+                    }
+                }
+            });
+
+            gameMenuItems.Add(new GameMenuItem
+            {
+                Description = "2 Stars",
+                MenuSection = $"Theme Extras | Ratings | Set User Rating",
+
+                Action = (mainMenuItem) =>
+                {
+                    var games = args.Games.Distinct();
+
+                    foreach (Game game in games)
+                    {
+                        game.UserScore = 40;
+                        Playnite.SDK.API.Instance.Database.Games.Update(game);
+                    }
+                }
+            });
+
+            gameMenuItems.Add(new GameMenuItem
+            {
+                Description = "3 Stars",
+                MenuSection = $"Theme Extras | Ratings | Set User Rating",
+
+                Action = (mainMenuItem) =>
+                {
+                    var games = args.Games.Distinct();
+
+                    foreach (Game game in games)
+                    {
+                        game.UserScore = 60;
+                        Playnite.SDK.API.Instance.Database.Games.Update(game);
+                    }
+                }
+            });
+
+            gameMenuItems.Add(new GameMenuItem
+            {
+                Description = "4 Stars",
+                MenuSection = $"Theme Extras | Ratings | Set User Rating",
+
+                Action = (mainMenuItem) =>
+                {
+                    var games = args.Games.Distinct();
+
+                    foreach (Game game in games)
+                    {
+                        game.UserScore = 80;
+                        Playnite.SDK.API.Instance.Database.Games.Update(game);
+                    }
+                }
+            });
+
+            gameMenuItems.Add(new GameMenuItem
+            {
+                Description = "5 Stars",
+                MenuSection = $"Theme Extras | Ratings | Set User Rating",
+
+                Action = (mainMenuItem) =>
+                {
+                    var games = args.Games.Distinct();
+
+                    foreach (Game game in games)
+                    {
+                        game.UserScore = 100;
+                        Playnite.SDK.API.Instance.Database.Games.Update(game);
+                    }
+                }
+            });
+
+            return gameMenuItems;
+        }
+
         public override void OnGameInstalled(OnGameInstalledEventArgs args)
         {
             // Add code to be executed when game is finished installing.


### PR DESCRIPTION
If you drag a star rating to 0, the "isDragging" variable is never set to False, and because UserScore hitting 0 results in it being set to null it removes it. So when you hover over another games star rating the values will continue to change.

I have added a context menu that will allow the users set a specific star rating without having to drag or use the user score value in the games edit menu